### PR TITLE
Fix main nav responsiveness and keyboard access

### DIFF
--- a/_includes/top-nav.html
+++ b/_includes/top-nav.html
@@ -1,10 +1,14 @@
-<nav class="top-nav" role="navigation" aria-label="Main Navigation">
+<nav class="top-nav" aria-label="Main">
   <div class="brand">
     <a class="brand__text" href={{"/" | relative_url }} title="Home">
       <span class="text--pink">Advancing</span>
       <span class="text--light-aqua">Foundation</span>
       <span class="text--gold">Archives</span>
     </a>
+  </div>
+
+  <div class="top-nav__mobile">
+    <button id="nav-toggle" aria-label="menu" aria-expanded="false"><span aria-hidden="true">☰</span></button>
   </div>
 
   <ul class="top-nav__list">
@@ -19,10 +23,5 @@
     <li class="top-nav__item{% if page.url contains 'resources' %} top-nav__item--active{% endif %}">
       <a href={{"/resources/" | relative_url }}>Resources</a>
     </li>
-
   </ul>
-
-  <div class="top-nav__mobile">
-    <button id="nav-toggle" aria-label="menu" aria-expanded="false"><span aria-hidden="true">☰</span></button>
-  </div>
-</nav>
+  </nav>

--- a/_sass/top-nav.scss
+++ b/_sass/top-nav.scss
@@ -79,6 +79,7 @@
 
 .brand {
   padding: 24px 20px;
+  flex-wrap: wrap;
   @include lg-up {
     padding: 30px 36px;
   }
@@ -86,6 +87,7 @@
 
 .brand__text {
   display: flex;
+  flex-wrap: wrap;
   font-size: 16px;
   font-weight: 900;
   text-decoration: none;
@@ -93,6 +95,7 @@
     text-decoration: none;
   }
   @include lg-up {
+    flex-wrap: nowrap;
     font-size: 36px;
   }
 }


### PR DESCRIPTION
Fix #72 

- Moves mobile menu toggle button above dropdown list in nav DOM to ensure correct keyboard navigation order.
- Removes redundant "navigation" role and label for less verbose/redundant screen reader experience
- Fixes mobile/screen magnification issue to keep menu nav toggle visible on small/magnified screens

Nav with keyboard focus at 320px width before:
<img width="1280" height="259" alt="image" src="https://github.com/user-attachments/assets/f18befd6-ef7e-4338-bd92-4dcb405d96d1" />

Nav with keyboard focus at 320px width after:
<img width="1279" height="240" alt="image" src="https://github.com/user-attachments/assets/e66b931c-3242-4608-9fa3-d60f57e5b251" />

